### PR TITLE
Restored original repository URL

### DIFF
--- a/dtd-parser/pom.xml
+++ b/dtd-parser/pom.xml
@@ -52,8 +52,8 @@
     <url>http://dtd-parser.java.net/</url>
 
     <scm>
-        <connection>scm:git:git@github.com/javaee/jaxb-dtd-parser.git</connection>
-        <developerConnection>scm:git:git@github.com/javaee/jaxb-dtd-parser.git</developerConnection>
+        <connection>scm:git:ssh://git@github.com/javaee/jaxb-dtd-parser.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/javaee/jaxb-dtd-parser.git</developerConnection>
         <url>https://github.com/javaee/jaxb-dtd-parser</url>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
Looks like my last change in SCM section broke the release build. Reverting back to original string.